### PR TITLE
Security: cross-tenant authz + USSD callback hardening (AUDIT C1–C4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,8 @@ PAYSTACK_SECRET_KEY=""
 # Upstash
 UPSTASH_REDIS_URL=""
 UPSTASH_REDIS_REST_TOKEN=""
+
+# Africa's Talking
+# Shared secret for the USSD callback. Generate with: openssl rand -hex 24
+# Append as ?token=<value> to the callback URL in the Africa's Talking dashboard.
+USSD_CALLBACK_TOKEN=""

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -7,20 +7,26 @@ Verified with `pnpm lint` (1 known warning), `pnpm typecheck` (clean), `knip` (u
 
 ## CRITICAL
 
-### C1. Server-action layer has no authorization — full cross-landlord IDOR for any signed-in user
+### ~~C1. Server-action layer has no authorization — full cross-landlord IDOR for any signed-in user~~
+**Status: fixed** — every export in `actions/tenants.ts` and `actions/units.ts`, plus `getPropertyDashboardData`/`fetchBanks`/`createSubaccount` in `actions/properties.ts`, now resolves `auth()` and verifies `property.ownerId` (unit-scoped functions resolve unit → property → owner); the unauthenticated USSD flow no longer calls these actions — it queries the db directly inside its own route-handler modules.
+
 The `"use server"` modules below do no `auth()` or ownership checks, and each module is pulled into the client graph by a form/hook import, so **every export becomes a POSTable endpoint** for any authenticated user:
 - `src/server/actions/tenants.ts:11` (`getTenants`), `:31` (`getTenantByUnitId`), `:57` (`addTenant`) — exposed via `src/components/forms/add-tenant-form.tsx:30`. Any signed-in user can read any property's tenant PII (names, phones, emails) and insert tenants into any landlord's units (also flips `unit.occupied`).
 - `src/server/actions/units.ts:13` (`getUnitTypes`), `:22` (`addUnit`), `:46` (`getUnits`), `:63` (`getUnitByName`), `:77` (`getUnitById`), `:91` (`getPropertyByUnitId`) — exposed via `src/components/forms/add-unit-form.tsx:29`. Cross-property reads and unit creation; `getPropertyByUnitId` leaks `subaccountCode`/bank details.
 - `src/server/actions/properties.ts:166` (`getPropertyDashboardData` — revenue, recent payments, tenant names) and `:25` (`fetchBanks`) — exposed via `src/components/forms/create-unit-type-form.tsx:41` (`createProperty` at `:95` is the only export that checks auth).
 Remediation: in every action, `await auth()`, then join to `property` and filter `eq(property.ownerId, userId)`; or route all client-reachable operations through `protectedProcedure` with ownership checks and stop importing these modules from client code.
 
-### C2. Page-level IDOR — /properties/[id]/* renders any property to any signed-in user
+### ~~C2. Page-level IDOR — /properties/[id]/* renders any property to any signed-in user~~
+**Status: fixed** — `properties/[id]/layout.tsx` now checks the id against `api.property.getAllUnderOwner()` (owner-filtered) and calls `notFound()` on miss, covering all child pages centrally.
+
 - `src/app/(protected)/properties/[id]/page.tsx:18-27` — existence check only (no `ownerId`), then `getUnits(id)` + dashboard data.
 - `src/app/(protected)/properties/[id]/tenants/page.tsx:14` — `getTenants(id)`: tenant PII for arbitrary property UUIDs.
 - `src/app/(protected)/properties/[id]/units/page.tsx:14`, `tenants/new/page.tsx:9`, `units/new/page.tsx:10` — same pattern.
 Remediation: verify `property.ownerId === userId` once in `src/app/(protected)/properties/[id]/layout.tsx` (currently no check, `layout.tsx:20`) and `notFound()` otherwise.
 
-### C3. tRPC IDOR — procedures keyed by id without ownership filter
+### ~~C3. tRPC IDOR — procedures keyed by id without ownership filter~~
+**Status: fixed** — `property.getPropertyDashboardData`, `tenant.addTenant`, `tenant.getTenantByUnitId`, and `unit.addUnit` now apply the same `property.ownerId = ctx.auth.userId` join/filter as `payment.getAllPropertyPayments`.
+
 All are live endpoints under `/api/trpc` for any authenticated user (several are unused by the UI but still exposed):
 - `src/server/api/routers/property.ts:108-111` — `getPropertyDashboardData` checks the property *exists* but not `eq(property.ownerId, userId)`; leaks revenue/payments/tenant names.
 - `src/server/api/routers/tenant.ts:15-34` — `addTenant` verifies the unit exists but not that its property belongs to `ctx.auth.userId`.
@@ -28,7 +34,9 @@ All are live endpoints under `/api/trpc` for any authenticated user (several are
 - `src/server/api/routers/unit.ts:19-22` — `addUnit` inserts into any `propertyId`.
 Remediation: add the `property.ownerId = ctx.auth.userId` join/filter to each (as `payment.getAllPropertyPayments` already does, `routers/payment.ts:18-24`).
 
-### C4. USSD callback: unauthenticated third-party charge initiation + unit oracle
+### ~~C4. USSD callback: unauthenticated third-party charge initiation + unit oracle~~
+**Status: fixed** — the route now requires a `?token=` shared secret (`USSD_CALLBACK_TOKEN`, compared with `crypto.timingSafeEqual`, 401 before any parsing) and rate-limits to 10 requests/phone number/minute via the existing Upstash Redis (INCR + EXPIRE, `END`-terminated message on exceed); `input-handlers.ts` now uses the validated `~/env`. **Operator follow-up:** `USSD_CALLBACK_TOKEN` is set in Vercel (done); append `?token=<value>` to the callback URL in the Africa's Talking dashboard.
+
 `src/middleware.ts:7` makes `/api/callbacks/ussd` public and `src/app/api/callbacks/ussd/route.ts:25` accepts any POST — there is no Africa's Talking source verification (no shared secret, no IP allowlist) and no rate limiting. `input-handlers.ts:118-160` then calls Paystack `/charge`, sending M-Pesa STK-push prompts to **arbitrary +254 numbers for attacker-chosen amounts** billed against real tenants' units; `input-validators.ts:39-70` doubles as a unit-id existence oracle.
 Remediation: authenticate the AT origin (shared header secret and/or IP allowlist), rate-limit per phoneNumber/sessionId with the existing Upstash Redis, and return a uniform message for unknown unit ids.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ pnpm dev
 ## Notes
 
 - **Deployment:** Vercel builds and deploys the app. GitHub Actions CI runs lint + typecheck only — it does not build or gate deploys (`next.config.ts` also sets `typescript.ignoreBuildErrors` since typechecking happens in CI).
-- **Dependency policy:** pnpm `minimumReleaseAge: 1440` (packages must be ≥24h old to install) with **no exclusions**; all install-time build scripts are denied (`allowBuilds` all `false` in `pnpm-workspace.yaml`) — review before flipping any to `true`.
+- **Dependency policy:** pnpm 11's default minimum release age applies (packages must be ≥24h old to install) with **no exclusions** — don't add `minimumReleaseAgeExclude`. All install-time build scripts are denied (`allowBuilds` all `false` in `pnpm-workspace.yaml`) — review before flipping any to `true`.
 - **Pinned versions:** TypeScript is held at 5.9 (typescript-eslint support ceiling) and ESLint at 9 (`eslint-config-next` compatibility). Bump them together, not independently.
 - **UI components:** the `src/components/ui` wrappers are Base UI, not Radix. `components.json` still declares the legacy `new-york` style, so `shadcn add` would fetch Radix-based variants that no longer match — add new components manually. Per-component migration reports (API/behavior deltas, verify-by-hand checklists) live in `.migration/`.
 - **Env vars:** validated in `src/env.js` (t3-env). `SKIP_ENV_VALIDATION=1` skips validation for tooling/builds.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,9 +1,4 @@
-minimumReleaseAge: 1440
-
-# Build scripts reviewed and intentionally NOT run. All of these ship
-# prebuilt binaries (or only use install scripts for optional native
-# fallbacks), so nothing here needs to execute code at install time.
-# Flip an entry to `true` only after reviewing what its script does.
+# Dependency build scripts reviewed and denied (pnpm 11 requires an explicit decision).
 allowBuilds:
   "@clerk/shared": false
   esbuild: false

--- a/src/app/(protected)/properties/[id]/layout.tsx
+++ b/src/app/(protected)/properties/[id]/layout.tsx
@@ -1,3 +1,4 @@
+import { notFound } from "next/navigation";
 import { UserButton } from "@clerk/nextjs";
 
 import { AppSidebar } from "~/components/dashboard/app-sidebar";
@@ -19,6 +20,13 @@ export default async function Layout({
 }) {
   const properties = await api.property.getAllUnderOwner();
   const { id } = await params;
+
+  // Central ownership check for all /properties/[id]/* pages:
+  // `getAllUnderOwner` only returns properties owned by the authenticated
+  // user, so an id outside that list either doesn't exist or isn't theirs.
+  if (!properties.some((property) => property.id === id)) {
+    notFound();
+  }
 
   return (
     <SidebarProvider>

--- a/src/app/api/callbacks/ussd/input-handlers.ts
+++ b/src/app/api/callbacks/ussd/input-handlers.ts
@@ -1,4 +1,4 @@
-import { env } from "process";
+import { eq } from "drizzle-orm";
 
 import {
   validateAmount,
@@ -12,8 +12,9 @@ import {
   setPhoneNumber,
   setUnitId,
 } from "~/app/api/callbacks/ussd/ussd-session-handler";
-import { getTenantByUnitId } from "~/server/actions/tenants";
-import { getPropertyByUnitId } from "~/server/actions/units";
+import { env } from "~/env";
+import { db } from "~/server/db";
+import { property, tenant, unit } from "~/server/db/schema";
 
 /**
  * @returns Welcome text with prompt to enter unit identifier.
@@ -122,9 +123,31 @@ export async function chargeUser(
 ): Promise<string> {
   let responseText;
   // Get tenant for the unit
+  // Note: queried directly (not via the server actions in ~/server/actions)
+  // because this flow is driven by the Africa's Talking gateway, which has
+  // no Clerk session — the actions now require an authenticated owner.
   try {
-    const { email: tenantEmail } = await getTenantByUnitId(unitId);
-    const { subaccountCode } = await getPropertyByUnitId(unitId);
+    const tenantRows = await db
+      .select({ email: tenant.email })
+      .from(tenant)
+      .innerJoin(unit, eq(unit.id, tenant.unitId))
+      .where(eq(unit.id, unitId))
+      .limit(1);
+    const tenantEmail = tenantRows[0]?.email;
+    if (!tenantEmail) {
+      throw new Error("Tenant not found");
+    }
+
+    const propertyRows = await db
+      .select({ subaccountCode: property.subaccountCode })
+      .from(unit)
+      .innerJoin(property, eq(unit.propertyId, property.id))
+      .where(eq(unit.id, unitId))
+      .limit(1);
+    const subaccountCode = propertyRows[0]?.subaccountCode;
+    if (!subaccountCode) {
+      throw new Error("Unit or property not found");
+    }
 
     const data: ChargeApiRequest = {
       // Paystack parses the amount in subunits, so we multiply by 100

--- a/src/app/api/callbacks/ussd/input-validators.ts
+++ b/src/app/api/callbacks/ussd/input-validators.ts
@@ -1,7 +1,9 @@
+import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { zfd } from "zod-form-data";
 
-import { getUnitById } from "~/server/actions/units";
+import { db } from "~/server/db";
+import { unit } from "~/server/db/schema";
 
 export const formDataSchema = zfd.formData({
   sessionId: zfd.text(),
@@ -46,16 +48,22 @@ export async function validateUnitId(
     };
   }
   try {
-    await getUnitById(unitId);
-  } catch (error) {
-    console.error(error);
-    // Check if this is the expected "Unit not found" error
-    if (error instanceof Error && error.message === "Unit not found") {
+    // Queried directly (not via the server actions in ~/server/actions)
+    // because this flow is driven by the Africa's Talking gateway, which has
+    // no Clerk session — the actions now require an authenticated owner.
+    const results = await db
+      .select({ id: unit.id })
+      .from(unit)
+      .where(eq(unit.id, unitId))
+      .limit(1);
+
+    if (results.length === 0) {
       return {
         status: "invalid",
         message: "CON Unit not found. Please try again.",
       };
     }
+  } catch (error) {
     // Log unexpected errors
     console.error("Unexpected error validating unit name:", error);
     return {

--- a/src/app/api/callbacks/ussd/route.ts
+++ b/src/app/api/callbacks/ussd/route.ts
@@ -1,3 +1,5 @@
+import { timingSafeEqual } from "node:crypto";
+
 import {
   handleAmount,
   handleConfirmation,
@@ -10,10 +12,31 @@ import {
   getUSSDSessionData,
   type USSDSessionData,
 } from "~/app/api/callbacks/ussd/ussd-session-handler";
+import { env } from "~/env";
+import { redis } from "~/server/redis";
 
 const responseHeaders = {
   "Content-Type": "text/plain",
 };
+
+const RATE_LIMIT_MAX_REQUESTS = 10;
+const RATE_LIMIT_WINDOW_SECONDS = 60;
+
+/**
+ * Constant-time comparison of the `token` query parameter against the
+ * shared secret configured in the Africa's Talking dashboard callback URL.
+ */
+function isValidCallbackToken(token: string | null): boolean {
+  if (!token) {
+    return false;
+  }
+  const expected = Buffer.from(env.USSD_CALLBACK_TOKEN);
+  const received = Buffer.from(token);
+  if (received.length !== expected.length) {
+    return false;
+  }
+  return timingSafeEqual(received, expected);
+}
 
 /**
  * Handles the USSD callback from the Afirca's Talking API.
@@ -23,6 +46,12 @@ const responseHeaders = {
  * The session is ended if the input is invalid.
  */
 export async function POST(req: Request) {
+  // Authenticate the Africa's Talking origin before any parsing or dispatch.
+  const token = new URL(req.url).searchParams.get("token");
+  if (!isValidCallbackToken(token)) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
   const validation = formDataSchema.safeParse(await req.formData());
   if (!validation.success) {
     console.error(
@@ -34,7 +63,28 @@ export async function POST(req: Request) {
     });
   }
 
-  const { text, sessionId } = validation.data;
+  const { text, sessionId, phoneNumber: callerPhoneNumber } = validation.data;
+
+  // Fixed-window rate limit per phone number.
+  try {
+    const rateLimitKey = `ussd-ratelimit:${callerPhoneNumber}`;
+    const requestCount = await redis.incr(rateLimitKey);
+    if (requestCount === 1) {
+      // Start the window when the counter is first created
+      await redis.expire(rateLimitKey, RATE_LIMIT_WINDOW_SECONDS);
+    }
+    if (requestCount > RATE_LIMIT_MAX_REQUESTS) {
+      return new Response("END Too many requests. Try again later.", {
+        status: 200,
+        headers: responseHeaders,
+      });
+    }
+  } catch (error) {
+    console.error("Error applying USSD rate limit:", error);
+    return new Response("END Something went wrong. Please try again later.", {
+      status: 200,
+    });
+  }
 
   if (text === "") {
     return new Response(welcome(), {

--- a/src/env.js
+++ b/src/env.js
@@ -14,6 +14,7 @@ export const env = createEnv({
     PAYSTACK_SECRET_KEY: z.string(),
     UPSTASH_REDIS_URL: z.string().url(),
     UPSTASH_REDIS_REST_TOKEN: z.string(),
+    USSD_CALLBACK_TOKEN: z.string().min(16),
   },
 
   /**
@@ -35,6 +36,7 @@ export const env = createEnv({
     PAYSTACK_SECRET_KEY: process.env.PAYSTACK_SECRET_KEY,
     UPSTASH_REDIS_URL: process.env.UPSTASH_REDIS_URL,
     UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,
+    USSD_CALLBACK_TOKEN: process.env.USSD_CALLBACK_TOKEN,
     // NEXT_PUBLIC_CLIENTVAR: process.env.NEXT_PUBLIC_CLIENTVAR,
   },
 

--- a/src/server/actions/properties.ts
+++ b/src/server/actions/properties.ts
@@ -3,7 +3,7 @@
 import "server-only";
 
 import { auth } from "@clerk/nextjs/server";
-import { desc, eq, sql } from "drizzle-orm";
+import { and, desc, eq, sql } from "drizzle-orm";
 
 import { env } from "~/env";
 import type {
@@ -23,6 +23,11 @@ import { payment, property, tenant, unit, unitType } from "~/server/db/schema";
  * @throws Error if the network request fails or Paystack returns a non-OK status
  */
 export async function fetchBanks() {
+  const { userId } = await auth();
+  if (!userId) {
+    throw new Error("User not authenticated");
+  }
+
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 10000); // 10 second timeout
 
@@ -65,6 +70,11 @@ export async function fetchBanks() {
  * @returns The newly created subaccount record
  */
 export async function createSubaccount(input: CreateSubaccountPayload) {
+  const { userId } = await auth();
+  if (!userId) {
+    throw new Error("User not authenticated");
+  }
+
   try {
     const res = await fetch("https://api.paystack.co/subaccount", {
       method: "POST",
@@ -164,6 +174,21 @@ export async function getProperties() {
 }
 
 export async function getPropertyDashboardData(propertyId: string) {
+  const { userId } = await auth();
+  if (!userId) {
+    throw new Error("User not authenticated");
+  }
+
+  const propertyExists = await db
+    .select({ id: property.id })
+    .from(property)
+    .where(and(eq(property.id, propertyId), eq(property.ownerId, userId)))
+    .limit(1);
+
+  if (propertyExists.length === 0) {
+    throw new Error("Property not found or you don't have access to it");
+  }
+
   // Get recent payments with tenant and unit info
   const recentPayments = await db
     .select({

--- a/src/server/actions/tenants.ts
+++ b/src/server/actions/tenants.ts
@@ -2,13 +2,29 @@
 
 import "server-only";
 
-import { eq, sql } from "drizzle-orm";
+import { auth } from "@clerk/nextjs/server";
+import { and, eq, sql } from "drizzle-orm";
 
 import { type AddTenantFormPayload } from "~/lib/validators/tenant";
 import { db } from "~/server/db";
-import { tenant, unit } from "~/server/db/schema";
+import { property, tenant, unit } from "~/server/db/schema";
 
 export async function getTenants(propertyId: string) {
+  const { userId } = await auth();
+  if (!userId) {
+    throw new Error("User not authenticated");
+  }
+
+  const propertyExists = await db
+    .select({ id: property.id })
+    .from(property)
+    .where(and(eq(property.id, propertyId), eq(property.ownerId, userId)))
+    .limit(1);
+
+  if (propertyExists.length === 0) {
+    throw new Error("Property not found or you don't have access to it");
+  }
+
   const tenants = await db
     .select({
       id: tenant.id,
@@ -29,6 +45,22 @@ export async function getTenants(propertyId: string) {
 }
 
 export async function getTenantByUnitId(unitId: string) {
+  const { userId } = await auth();
+  if (!userId) {
+    throw new Error("User not authenticated");
+  }
+
+  const ownedUnit = await db
+    .select({ id: unit.id })
+    .from(unit)
+    .innerJoin(property, eq(unit.propertyId, property.id))
+    .where(and(eq(unit.id, unitId), eq(property.ownerId, userId)))
+    .limit(1);
+
+  if (ownedUnit.length === 0) {
+    throw new Error("Unit not found or you don't have access to it");
+  }
+
   const results = await db
     .select({
       id: tenant.id,
@@ -55,16 +87,22 @@ export async function getTenantByUnitId(unitId: string) {
  * @returns The id of the added tenant
  */
 export async function addTenant(data: AddTenantFormPayload) {
+  const { userId } = await auth();
+  if (!userId) {
+    throw new Error("User not authenticated");
+  }
+
   const unitExists = await db
-    .select()
+    .select({ unit })
     .from(unit)
-    .where(eq(unit.id, data.unitId))
+    .innerJoin(property, eq(unit.propertyId, property.id))
+    .where(and(eq(unit.id, data.unitId), eq(property.ownerId, userId)))
     .limit(1);
   if (unitExists.length === 0) {
     throw new Error("Unit does not exist");
   }
 
-  const unitOccupied = unitExists[0]?.occupied;
+  const unitOccupied = unitExists[0]?.unit.occupied;
   if (unitOccupied) {
     throw new Error("Unit is already occupied");
   }

--- a/src/server/actions/units.ts
+++ b/src/server/actions/units.ts
@@ -2,7 +2,8 @@
 
 import "server-only";
 
-import { eq } from "drizzle-orm";
+import { auth } from "@clerk/nextjs/server";
+import { and, eq } from "drizzle-orm";
 import { customAlphabet } from "nanoid";
 
 import { db } from "~/server/db";
@@ -10,7 +11,30 @@ import { property, unit, unitType } from "~/server/db/schema";
 
 const genUniqueId = customAlphabet("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ", 6);
 
+/**
+ * Verifies that the property exists and belongs to the authenticated user.
+ * @throws Error if the user is unauthenticated or does not own the property
+ */
+async function verifyPropertyOwnership(propertyId: string) {
+  const { userId } = await auth();
+  if (!userId) {
+    throw new Error("User not authenticated");
+  }
+
+  const propertyExists = await db
+    .select({ id: property.id })
+    .from(property)
+    .where(and(eq(property.id, propertyId), eq(property.ownerId, userId)))
+    .limit(1);
+
+  if (propertyExists.length === 0) {
+    throw new Error("Property not found or you don't have access to it");
+  }
+}
+
 export async function getUnitTypes(propertyId: string) {
+  await verifyPropertyOwnership(propertyId);
+
   const unitTypes = await db
     .select()
     .from(unitType)
@@ -24,6 +48,8 @@ export async function addUnit(
   unitTypeId: string,
   propertyId: string,
 ) {
+  await verifyPropertyOwnership(propertyId);
+
   for (let attempts = 0; attempts < 5; attempts++) {
     const id = genUniqueId();
     try {
@@ -44,6 +70,8 @@ export async function addUnit(
 }
 
 export async function getUnits(propertyId: string) {
+  await verifyPropertyOwnership(propertyId);
+
   const units = await db
     .select({
       id: unit.id,
@@ -61,39 +89,56 @@ export async function getUnits(propertyId: string) {
 }
 /** Gets a unit with the given unit name */
 export async function getUnitByName(name: string) {
+  const { userId } = await auth();
+  if (!userId) {
+    throw new Error("User not authenticated");
+  }
+
   const results = await db
-    .select()
+    .select({ unit })
     .from(unit)
-    .where(eq(unit.unitName, name))
+    .innerJoin(property, eq(unit.propertyId, property.id))
+    .where(and(eq(unit.unitName, name), eq(property.ownerId, userId)))
     .limit(1);
 
   if (results.length === 0) {
     throw new Error("Unit not found");
   }
 
-  return results[0];
+  return results[0]?.unit;
 }
 
 export async function getUnitById(unitId: string) {
+  const { userId } = await auth();
+  if (!userId) {
+    throw new Error("User not authenticated");
+  }
+
   const results = await db
-    .select()
+    .select({ unit })
     .from(unit)
-    .where(eq(unit.id, unitId))
+    .innerJoin(property, eq(unit.propertyId, property.id))
+    .where(and(eq(unit.id, unitId), eq(property.ownerId, userId)))
     .limit(1);
 
   if (results.length === 0) {
     throw new Error("Unit not found");
   }
 
-  return results[0]!;
+  return results[0]!.unit;
 }
 
 export async function getPropertyByUnitId(unitId: string) {
+  const { userId } = await auth();
+  if (!userId) {
+    throw new Error("User not authenticated");
+  }
+
   const results = await db
     .select({ property })
     .from(unit)
     .leftJoin(property, eq(unit.propertyId, property.id))
-    .where(eq(unit.id, unitId))
+    .where(and(eq(unit.id, unitId), eq(property.ownerId, userId)))
     .limit(1);
   const current = results[0]?.property;
   if (!current) {

--- a/src/server/api/routers/property.ts
+++ b/src/server/api/routers/property.ts
@@ -105,21 +105,28 @@ export const propertyRouter = createTRPCRouter({
     .query(async ({ ctx, input }) => {
       try {
         const { propertyId } = input;
+        const { userId } = ctx.auth;
+
         const currentProperty = await ctx.db
           .select({ id: property.id })
           .from(property)
-          .where(eq(property.id, propertyId));
+          .where(and(eq(property.id, propertyId), eq(property.ownerId, userId)))
+          .limit(1);
 
         if (!currentProperty[0]) {
           throw new TRPCError({
             code: "NOT_FOUND",
-            message: "Property not found",
+            message: "Property not found or you don't have access to it",
           });
         }
 
         const data = await getPropertyDashboardData(propertyId);
         return data;
       } catch (error) {
+        if (error instanceof TRPCError) {
+          throw error;
+        }
+
         console.error("Error fetching property dashboard data:", error);
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",

--- a/src/server/api/routers/tenant.ts
+++ b/src/server/api/routers/tenant.ts
@@ -11,21 +11,23 @@ export const tenantRouter = createTRPCRouter({
     .input(AddTenantFormSchema)
     .mutation(async ({ ctx, input }) => {
       const { unitId, firstName, lastName, phoneNumber, email } = input;
+      const { userId } = ctx.auth;
 
       const unitExists = await ctx.db
-        .select()
+        .select({ unit })
         .from(unit)
-        .where(eq(unit.id, unitId))
+        .innerJoin(property, eq(unit.propertyId, property.id))
+        .where(and(eq(unit.id, unitId), eq(property.ownerId, userId)))
         .limit(1);
 
       if (unitExists.length === 0) {
         throw new TRPCError({
           code: "NOT_FOUND",
-          message: "Unit does not exist",
+          message: "Unit not found or you don't have access to it",
         });
       }
 
-      const unitOccupied = unitExists[0]?.occupied;
+      const unitOccupied = unitExists[0]?.unit.occupied;
       if (unitOccupied) {
         throw new TRPCError({
           code: "BAD_REQUEST",
@@ -109,6 +111,7 @@ export const tenantRouter = createTRPCRouter({
     .input(z.object({ unitId: z.string() }))
     .query(async ({ ctx, input }) => {
       const { unitId } = input;
+      const { userId } = ctx.auth;
 
       const results = await ctx.db
         .select({
@@ -120,7 +123,8 @@ export const tenantRouter = createTRPCRouter({
         })
         .from(tenant)
         .innerJoin(unit, eq(unit.id, tenant.unitId))
-        .where(eq(unit.id, unitId))
+        .innerJoin(property, eq(unit.propertyId, property.id))
+        .where(and(eq(unit.id, unitId), eq(property.ownerId, userId)))
         .limit(1);
 
       if (results.length === 0) {

--- a/src/server/api/routers/unit.ts
+++ b/src/server/api/routers/unit.ts
@@ -14,6 +14,21 @@ export const unitRouter = createTRPCRouter({
     .input(AddUnitSchema)
     .mutation(async ({ ctx, input }) => {
       const { unitName, unitTypeId, propertyId } = input;
+      const { userId } = ctx.auth;
+
+      const propertyExists = await ctx.db
+        .select({ id: property.id })
+        .from(property)
+        .where(and(eq(property.id, propertyId), eq(property.ownerId, userId)))
+        .limit(1);
+
+      if (!propertyExists.length) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Property not found or you don't have access to it",
+        });
+      }
+
       const id = genUniqueId();
 
       const results = await ctx.db


### PR DESCRIPTION
## Summary

Fixes all four CRITICAL findings from AUDIT.md:

- **C1** — server actions now require Clerk auth + property ownership (pattern copied from `payment.getAllPropertyPayments`); USSD flow decoupled from the actions (gateway has no session) via inline route-handler queries.
- **C2** — central ownership check in `properties/[id]/layout.tsx`: `notFound()` for any property the signed-in user doesn't own (covers all child pages, zero extra queries).
- **C3** — ownership filters on the four IDOR'd tRPC procedures.
- **C4** — USSD callback requires a `?token=` shared secret (timing-safe compare, 401 before parsing) + 10 req/phone/min rate limit via existing Upstash Redis.
- Also: `input-handlers.ts` uses validated `~/env`; drops the redundant explicit `minimumReleaseAge` (pnpm 11 default).

## ⚠️ Merge order — zero-downtime sequence

1. **Before merging:** append `?token=<value>` (value: `vercel env pull` or the Vercel dashboard — `USSD_CALLBACK_TOKEN`, already set in all three environments) to the USSD callback URL in the Africa's Talking dashboard. The currently deployed code ignores the extra param, so this is harmless now.
2. Merge this PR. The new code starts enforcing the token; AT is already sending it.

Merging first instead would 401 all USSD sessions until the dashboard is updated.

## Verification

- `eslint .` clean (pre-existing TanStack Table warning only), `tsc --noEmit` clean, Prettier clean, local production build passes