### PR TITLE
chore: adopt shared renovate-config preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "rangeStrategy": "bump",
-  "automerge": true
+  "extends": [
+    "github>peterkibuchi/renovate-config"
+  ]
 }


### PR DESCRIPTION
Swaps local Renovate policy for the shared preset (github>peterkibuchi/renovate-config). Repo-specific rules preserved.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/msplke/codesmith/kejaniverse/pr/940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the automated dependency-management configuration to use a shared Renovate preset.
  * Standardized Renovate defaults and simplified the configuration by removing redundant per-repo settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->