### PR TITLE
ci: add Blacksmith testbox workflow

### DIFF
--- a/.github/workflows/ci-typecheck-testbox.yml
+++ b/.github/workflows/ci-typecheck-testbox.yml
@@ -1,0 +1,39 @@
+name: Blacksmith Testbox
+on:
+  workflow_dispatch:
+    inputs:
+      testbox_id:
+        type: string
+        description: "Testbox session ID"
+        required: true
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+jobs:
+  typecheck:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Begin Testbox
+        uses: useblacksmith/begin-testbox@v2
+        with:
+          testbox_id: ${{ inputs.testbox_id }}
+
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6.0.10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24.19.0
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run Testbox
+        uses: useblacksmith/run-testbox@v2
+        if: always()


### PR DESCRIPTION
Adds the Testbox workflow generated by `blacksmith testbox init` (from `ci.yml`'s typecheck job): checkout + pnpm + Node + install, wrapped in `begin-testbox`/`run-testbox`. Enables warm-box CI-parity runs (`verify-parity`) for this repo.

The generated `.claude/skills/blacksmith-testbox/` file is deliberately not committed — local agent config stays untracked in public repos.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/msplke/codesmith/kejaniverse/pr/971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a manually triggered CI workflow for running Testbox sessions.
  * Added automatic Testbox checks for pull requests that modify workflow configuration.
  * Standardized the workflow environment with Node.js and pnpm setup, dependency installation, and caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->