### PR TITLE
ci: testbox workflow becomes dispatch-only

### DIFF
--- a/.github/workflows/ci-typecheck-testbox.yml
+++ b/.github/workflows/ci-typecheck-testbox.yml
@@ -6,12 +6,8 @@ on:
         type: string
         description: "Testbox session ID"
         required: true
-  pull_request:
-    paths:
-      - '.github/workflows/**'
-
 jobs:
-  typecheck:
+  testbox:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Begin Testbox

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ yarn-error.log*
 
 # idea files
 .idea
+# local agent config — personal tooling, never committed (public repo)
+.claude/


### PR DESCRIPTION
Fixes two defects in the workflow added by #971:

- Drops the `pull_request` trigger: it started a testbox job on every PR touching workflows (it already fired on a Renovate PR, run 33146636665) with an empty `testbox_id`. The Blacksmith CLI dispatches this workflow explicitly; `workflow_dispatch` is the only trigger it needs.
- Renames the job `typecheck` → `testbox` so it no longer collides with `ci.yml`'s real `typecheck` job in check lists.

Also gitignores `.claude/` — local agent config is personal tooling and shouldn't be committable in a public repo.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/msplke/codesmith/kejaniverse/pr/972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the test workflow to run manually with a specified testbox.
  * Improved testbox setup and execution using the latest Node.js environment.
  * Added local agent configuration files to the list of ignored files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->